### PR TITLE
Proposed change for uniforms to avoid raw pointers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -833,6 +833,26 @@ impl UniformType {
     }
 }
 
+/// Marker trait for uniforms.
+pub trait Uniform {}
+
+/// A single floating point uniform.
+pub type Float = f32;
+/// A uniform containing two floating point numbers.
+pub type Float2 = [Float; 2];
+/// A uniform containing three floating point numbers.
+pub type Float3 = [Float; 3];
+/// A uniform containing four floating point numbers.
+pub type Float4 = [Float; 4];
+/// A uniform built from a 4x4 matrix of floating point numbers.
+pub type Mat4 = [Float4; 4];
+impl Uniform for Float {}
+impl Uniform for Float2 {}
+impl Uniform for Float3 {}
+impl Uniform for Float4 {}
+impl Uniform for Mat4 {}
+
+
 /// The face-culling mode.
 ///
 /// This is used in the [`PipelineDesc`] `rasterizer`'s
@@ -1605,18 +1625,18 @@ impl Context {
     }
 
     /// Update shader uniform data.
-    pub fn apply_uniform_block(
+    pub fn apply_uniform_block<T>(
         &mut self,
         stage: ShaderStage,
         ub_index: u32,
-        data: *const os::raw::c_void,
-        num_bytes: u32,
-    ) {
+        data: Vec<T>)
+    where
+        T: Uniform,
+    {
         assert!(ub_index < MAX_SHADERSTAGE_UBS as u32);
-        assert!(!data.is_null() && (num_bytes > 0));
+        assert!(data.len() > 0);
         if self.pass_valid && self.next_draw_valid {
-            self.backend
-                .apply_uniform_block(stage, ub_index, data, num_bytes);
+            self.backend.apply_uniform_block(stage, ub_index, data);
         }
     }
 

--- a/src/opengl/backend.rs
+++ b/src/opengl/backend.rs
@@ -8,9 +8,8 @@ use opengl::gleam::gl::types::{GLenum, GLint, GLuint};
 use opengl::gleam::gl::{self, Gl};
 use opengl::*;
 use std::collections::HashSet;
-use std::os;
 
-use {Config, Feature, ShaderStage};
+use {Config, Feature, ShaderStage, Uniform};
 
 const GL_TEXTURE_MAX_ANISOTROPY_EXT: GLuint = 0x84FE;
 const GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT: GLuint = 0x84FF;
@@ -277,13 +276,14 @@ impl Backend {
             .scissor(x as i32, y as i32, width as i32, height as i32);
     }
 
-    pub fn apply_uniform_block(
+    pub fn apply_uniform_block<T>(
         &mut self,
         stage: ShaderStage,
         ub_index: u32,
-        data: *const os::raw::c_void,
-        num_bytes: u32,
-    ) {
+        data: Vec<T>)
+    where
+        T: Uniform,
+    {
         unimplemented!();
     }
 


### PR DESCRIPTION
This change removes the use of a raw pointer + bytecount from `apply_uniform_block()`.

I'd prefer to work out the remaining uses of raw pointers in the public interfaces elsewhere as well.